### PR TITLE
update readme to generate documentation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,8 @@
-Some usage examples can be found in demotest.d.  Unfortunately the ddoc documentation for
-this library doesn't compile due to DMD bug 5704.
+Some usage examples can be found in demotest.d.
+
+Build documentation:
+
+dmd -o- -Dddoc *.d
 
 Build instructions:
 
@@ -18,4 +21,4 @@ dmd -O -inline -release -version=test *.d
 
 or
 
-dmd -O -inline -release -version=dfl -version=test *.d
+dmd -O -inline -release -version=test -version=dfl *.d

--- a/plot.d
+++ b/plot.d
@@ -29,13 +29,13 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
- 
- module plot2kill.plot;
- 
- import plot2kill.figure, plot2kill.util, plot2kill.hierarchical;
- import std.random, std.typetuple;
- 
- version(dfl) {
+
+module plot2kill.plot;
+
+import plot2kill.figure, plot2kill.util, plot2kill.hierarchical;
+import std.random, std.typetuple;
+
+version(dfl) {
     public import plot2kill.dflwrapper;
 } else {
     public import plot2kill.gtkwrapper;


### PR DESCRIPTION
update readme to generate documentation as plot2kill can now properly generate documentation with dmd 2.059 beta 4

remove initial white spaces on module/import lines in plot.d
